### PR TITLE
fix syn dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,15 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
 quote = "1.0"
+
+[dependencies.syn]
+version = "1.0"
+features = ["full"]
 
 [dev-dependencies]
 quickcheck = "0.9"
 futures = "0.3"
-syn = "1.0"
 quote = "1.0"
 
 [dev-dependencies.tokio]


### PR DESCRIPTION
`quickcheck_async` uses items from `syn` that are only available if the `full` feature is enabled, however it doesn't specify that in its dependency.

Often that isn't a problem, as many other things depend on `syn` and include that feature, and Cargo's feature unification means `full` gets enabled anyway.  You can reproduce this by removing all the dev-dependencies and running `cargo check`.

```
error[E0432]: unresolved imports `syn::FnArg`, `syn::ItemFn`, `syn::Pat`
   --> src/lib.rs:13:84
    |
13  |     parse_macro_input, punctuated::Punctuated, token::Comma, AttributeArgs, Error, FnArg, ItemFn,
    |                                                                                    ^^^^^  ^^^^^^ no `ItemFn` in the root
    |                                                                                    |
    |                                                                                    no `FnArg` in the root
14  |     NestedMeta, Pat, Type,
    |                 ^^^
    |                 |
    |                 no `Pat` in the root
    |                 help: a similar name exists in the module: `Path`
    |
note: found an item that was configured out
   --> /Users/mbthomas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-1.0.109/src/lib.rs:363:5
    |
363 |     FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
    |     ^^^^^
note: the item is gated behind the `full` feature
   --> /Users/mbthomas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-1.0.109/src/lib.rs:361:7
    |
361 | #[cfg(feature = "full")]
    |       ^^^^^^^^^^^^^^^^
note: found an item that was configured out
   --> /Users/mbthomas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-1.0.109/src/lib.rs:365:32
    |
365 |     ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMacro2, ItemMod,
    |                                ^^^^^^
note: the item is gated behind the `full` feature
   --> /Users/mbthomas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-1.0.109/src/lib.rs:361:7
    |
361 | #[cfg(feature = "full")]
    |       ^^^^^^^^^^^^^^^^
note: found an item that was configured out
   --> /Users/mbthomas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-1.0.109/src/lib.rs:417:15
    |
417 |     FieldPat, Pat, PatBox, PatIdent, PatLit, PatMacro, PatOr, PatPath, PatRange, PatReference,
    |               ^^^
note: the item is gated behind the `full` feature
   --> /Users/mbthomas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-1.0.109/src/lib.rs:415:7
    |
415 | #[cfg(feature = "full")]
    |       ^^^^^^^^^^^^^^^^
```

This PR adds the feature to the syn dependency explicitly so it's always provided.